### PR TITLE
fix: Resolve 'make site' build failure due to SASS error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
-module github.com/layer5io/academy-example
+module github.com/layer5io/exoscale-academy
 
 go 1.24.5
+
+require (
+    github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect
+    github.com/layer5io/academy-theme v0.1.19 // indirect
+    github.com/twbs/bootstrap v5.3.7+incompatible // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/layer5io/exoscale-academy
+module github.com/layer5io/academy-example
 
 go 1.24.5
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/layer5io/academy-theme v0.1.19 h1:X2BiWBGRi83lzQkXfz1DNKF5bgrxmj1raZYSxebB84Q=
+github.com/layer5io/academy-theme v0.1.19/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
+github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
### Description

The site fails to build due to a SASS compilation error:

When you ran `make site`, you encountered this error:

```
Error: error building site: TOCSS: failed to transform "/scss/main.scss": file to import not found or unreadable: ../vendor/Font-Awesome/scss/fontawesome.
```

The root cause is that essential Hugo module dependencies (`docsy`, `Font-Awesome`, etc.) are missing from the `go.mod` file. It appears that automated workflows, incorrectly clear these dependencies during updates.

The direct cause of go.mod being deleted is in PR #34.
A possible contributing factor is PR #30.

This issue also affects other repositories, including `layer5-academy` and `exoscale-academy`, which have had their `go.mod` files cleared.