### PR TITLE
broken image workflow

### DIFF
--- a/.github/workflows/broken-img.yml
+++ b/.github/workflows/broken-img.yml
@@ -1,0 +1,57 @@
+name: Validating Images
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.md'
+
+jobs:
+  read-markdown:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1  
+
+      - name: validate image formats
+        run: |
+          changed_files=$(git diff --name-only HEAD^ HEAD | grep '\.md$')
+          
+          has_invalid_images=false
+          
+          for file in $changed_files; do
+            if [ -f "$file" ]; then
+              echo "Checking $file for invalid image lines:"
+              # Find lines in ![alt](image-path) format
+              grep -n -E '!\[.*\]\(.*\)' "$file" | while IFS= read -r line; do
+                # Extract the image path syntax
+                image_path=$(echo "$line" | sed -E 's/.*!\[.*\]\((.*)\).*/\1/')
+                
+                # Check if image path is empty
+                if [ -z "$image_path" ]; then
+                  echo "::warning file=$file::Empty image path in line: $line"
+                  has_invalid_images=true
+                  continue
+                fi
+                
+                # Check image path extension (png, jpg, jpeg, gif, svg, webp)
+                
+                if ! echo "$image_path" | grep -qE '\.(png|jpg|jpeg|gif|svg|webp)$'; then
+                  echo "::warning file=$file::Invalid or missing image extension in line: $line"
+                  has_invalid_images=true
+                fi
+              done
+            else
+              echo "::warning::File $file not found"
+              has_invalid_images=true
+            fi
+          done
+          
+          if [ "$has_invalid_images" = true ]; then
+            echo "Validation failed: Found invalid image formats in Markdown files"
+            exit 1
+          else
+            echo "All image formats are valid"
+          fi


### PR DESCRIPTION
Notes for Reviewers
The workflow runs everytime in a PR there is a .md file , checks if it contains any invalid image format ( which can make images not rendered on page) and sends out a warning .

Supports png , jpg , jpeg , svg , gif , webp .
image

This PR fixes #
<img width="1068" height="111" alt="image" src="https://github.com/user-attachments/assets/2e4b662c-5bf6-4719-b0eb-6945978b2d86" />




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
