### PR TITLE
[Automated] Update academy-theme to v0.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.2.0 // indirect
+	github.com/layer5io/academy-theme v0.2.3 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/layer5io/academy-theme v0.1.20 h1:+FvUnCh3WSLC94gyU7mSGWdsVc0nHqf3/Td
 github.com/layer5io/academy-theme v0.1.20/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.2.0 h1:A95TZnGydXh8NF6DGITpooGxoTJTYOv8xMyIY0Gy3MQ=
 github.com/layer5io/academy-theme v0.2.0/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.2.3 h1:LSG2J0zndp4rrktw984dgrMu0r9liOHz44pGTbCG8jU=
+github.com/layer5io/academy-theme v0.2.3/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.2.3.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.