### PR TITLE
docs: add org-id shortcode demo page

### DIFF
--- a/content/content-formatting-examples/academy-theme/org-id.md
+++ b/content/content-formatting-examples/academy-theme/org-id.md
@@ -1,0 +1,21 @@
+---
+title: Org ID
+linkTitle: Org ID
+weight: 9
+description: Academy theme org-id shortcode for rendering the organization UUID.
+draft: true
+---
+
+The `org-id` shortcode renders the organization UUID extracted from the current page's content path.
+
+Academy content is organized as `content/<type>/<orgID>/...` where `<orgID>` is a UUID at path segment index 1. When the page is within such a structure, the shortcode outputs the UUID inline as a `<code>` element.
+
+```text
+{{</* org-id */>}}
+```
+
+**Example:**
+
+{{< org-id >}}
+
+> **Note:** This demo page is not under a UUID-named directory, so the shortcode renders the fallback text. When used within a `content/learning-paths/<uuid>/...` path, it will output the organization's UUID.

--- a/content/content-formatting-examples/academy-theme/org-id.md
+++ b/content/content-formatting-examples/academy-theme/org-id.md
@@ -8,7 +8,7 @@ draft: true
 
 The `org-id` shortcode renders the organization UUID extracted from the current page's content path.
 
-Academy content is organized as `content/<type>/<orgID>/...` where `<orgID>` is a UUID at path segment index 1. When the page is within such a structure, the shortcode outputs the UUID inline as a `<code>` element.
+Academy content is organized as `<type>/<orgID>/...` (relative to the content directory) where `<orgID>` is a UUID at path segment index 1. When the page is within such a structure, the shortcode outputs the UUID inline as a `<code>` element.
 
 ```text
 {{</* org-id */>}}


### PR DESCRIPTION
## Summary

- Adds `content/content-formatting-examples/academy-theme/org-id.md` to demonstrate the new `org-id` shortcode from `layer5io/academy-theme`
- The shortcode renders the organization UUID extracted from the page's content path (segment index 1)
- Demo page shows shortcode syntax, expected output, and explains fallback behavior when a page is outside a UUID-named directory

## Test plan

- [ ] Verify the new `org-id.md` page appears in the academy-theme formatting examples section
- [ ] Confirm the shortcode renders the fallback `(org ID not found)` since this demo page is not under a UUID directory