### PR TITLE
test: verify PR preview build/deploy workflow

### DIFF
--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -24,8 +24,6 @@ jobs:
   build-docs-preview:
     runs-on: ubuntu-24.04
     if: github.event.action != 'closed'
-    # env:
-    #   HUGO_VERSION: 0.158.0
 
     steps:
       # Hugo Module fetching hits proxy.golang.org and sum.golang.org. Harmless under egress-policy: audit, but if the harden-runner is promoted to block,
@@ -39,33 +37,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
-      # hugo-extended is one of the dependencies which gets added onto the node_modules whenever npm install is run,
-      # so the commented out code below serves as a second installation of hugo within the runner.
-      # the commented out code is to be removed if the pr preview builds successfully.
-
-      # - name: Install Hugo CLI
-      #   run: |
-      #     wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-      #     && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      # - name: Install Dart Sass
-      #   # Direct download from the dart-sass GitHub release rather than
-      #   # `sudo snap install dart-sass` (snap.io's storeserver was flaky
-      #   # in GitHub-hosted runners and broke this workflow on unrelated
-      #   # PRs, see #19574). Hugo Extended ships embedded Dart Sass as of
-      #   # v0.114+ but having the standalone binary on PATH is the most
-      #   # reliable path through `resources.toCSS` with transpiler "dartsass".
-      #   env:
-      #     DART_SASS_VERSION: 1.79.5
-      #   run: |
-      #     set -eu
-      #     cd "${RUNNER_TEMP}"
-      #     curl -fsSL -o dart-sass.tar.gz "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-      #     sudo tar -xzf dart-sass.tar.gz -C /usr/local/lib
-      #     sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/sass
-      #     sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/dart-sass
-      #     dart-sass --version
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -31,7 +31,7 @@ jobs:
           egress-policy: audit
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: docs-preview-build
           path: docs-preview-build
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: true
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: docs-preview-build
           path: docs-preview-build
@@ -85,18 +85,33 @@ jobs:
           umbrella-dir: pr-preview # must match the /pr-preview/ baseURL the build bakes
           qr-code: false
           comment: false
+          wait-for-pages-deployment: false
           action: ${{ needs.read-metadata.outputs.action == 'closed' && 'remove' || 'deploy' }}
           pr-number: ${{ needs.read-metadata.outputs.pr-number }}
 
+      - name: Build preview comment
+        if: needs.read-metadata.outputs.action != 'closed'
+        id: comment-body
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview-url }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "body<<EOF"
+            echo "🚀 Preview deployment: ${PREVIEW_URL}"
+            echo "> *Note: Preview may take a moment (GitHub Pages deployment in progress). Please wait and refresh. Track deployment [here](https://github.com/${REPO}/actions/workflows/pages/pages-build-deployment)*"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Comment preview URL
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-preview
           number: ${{ needs.read-metadata.outputs.pr-number }}
           message: |
             ${{ needs.read-metadata.outputs.action == 'closed'
             && 'Preview removed because the pull request was closed.'
-            || format('📖 Pull request preview: {0}', steps.preview.outputs.preview-url) }}
+            || steps.comment-body.outputs.body }}
 
   prune:
     needs: read-metadata
@@ -107,7 +122,7 @@ jobs:
       removed_prs_json: ${{ steps.prune-previews.outputs.removed_prs_json }}
     steps:
       - name: Checkout gh-pages for preview retention
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           fetch-depth: 0
@@ -201,7 +216,7 @@ jobs:
           fi
 
       - name: Comment on pruned previews
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REMOVED_PRS_JSON: ${{ steps.prune-previews.outputs.removed_prs_json }}
           PREVIEW_RETENTION_LIMIT: ${{ env.PREVIEW_RETENTION_LIMIT }}

--- a/content/certifications/your-org-uuid/certification-1/test-1.md
+++ b/content/certifications/your-org-uuid/certification-1/test-1.md
@@ -19,3 +19,5 @@ layout: "test"
 type: "test"
 ---
 <!-- preview workflow test: 2026-08-07T02:05:18Z -->
+
+<!-- preview workflow test v2: 2026-08-07T02:21:55Z -->

--- a/content/certifications/your-org-uuid/certification-1/test-1.md
+++ b/content/certifications/your-org-uuid/certification-1/test-1.md
@@ -18,3 +18,4 @@ questions:
 layout: "test"
 type: "test"
 ---
+<!-- preview workflow test: 2026-08-07T02:05:18Z -->


### PR DESCRIPTION
**Notes for Reviewers**
Test PR to validate the split build/deploy preview workflows on this repo:
- Confirms the build workflow triggers correctly on the watched `content/**` paths
- Confirms the preview page renders and the edit is visible
- Will be used to verify re-render on a new commit, and correct behavior on close/reopen

No actual content changes are intended — this is a throwaway test file edit
(`content/certifications/your-org-uuid/certification-1/test-1.md`) and this PR
will be closed without merging once verification is complete.

fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview deployments now post a sticky comment with the preview URL and a notice that deployment may still be in progress.
  - Closed previews continue to receive a removal message.
  - The first certification test is now labeled “Exam 1 (Preview Test)” for clarity.

- **Tests**
  - Updated preview workflow test content with timestamped comments.

- **Chores**
  - Improved preview deployment reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->